### PR TITLE
modify to reproduce environment with Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source :rubygems
 
 gem "rake"
-gem "rspec"
-gem "rr"
+gem "rspec", "2.7.0"
+gem "rr", "1.0.4"
 
 # add rdoc for darkfish format
 gem "rdoc"


### PR DESCRIPTION
This rspec files are very old style, so it is not working with this Gemfile. I modified Gemfile to generate old environment to work rspec. I checked my local environment with this Gemfile.

```
[tarr@localhost roma-ruby-client]$ rspec spec/roma/client/client_pool_spec.rb
........*..*...............

Pending:
  Roma::Client::ClientPool client
    # TODO: startup or mock roma server
    # ./spec/roma/client/client_pool_spec.rb:74
  Roma::Client::ClientPool client
    # TODO: check nodes
    # ./spec/roma/client/client_pool_spec.rb:82

Finished in 0.20596 seconds
27 examples, 0 failures, 2 pending
```