### PR TITLE
Use Timeout.timeout instead of Object#timeout since it's deprecated.

### DIFF
--- a/lib/roma/client/rclient.rb
+++ b/lib/roma/client/rclient.rb
@@ -1,6 +1,7 @@
 require 'digest/sha1'
 require 'socket'
 require 'singleton'
+require 'timeout'
 require 'roma/client/con_pool'
 require 'roma/client/client_rttable'
 require 'roma/client/sender'
@@ -402,7 +403,7 @@ module Roma
         nid, d = @rttable.search_node(key)
         cmd2 = sprintf(cmd, "#{key}\e#{@default_hash_name}", *params)
 
-        timeout(@@timeout){
+        Timeout.timeout(@@timeout){
           return @sender.send_command(nid, cmd2, value, receiver)
         }
       rescue => e

--- a/lib/roma/client/sender.rb
+++ b/lib/roma/client/sender.rb
@@ -10,7 +10,7 @@ module Roma
       end
 
       def send_route_mklhash_command(node_id)
-        timeout(1) do
+        Timeout.timeout(1) do
           conn = ConPool.instance.get_connection(node_id)
           conn.write "mklhash 0\r\n"
           ret = conn.gets
@@ -23,7 +23,7 @@ module Roma
       end
 
       def send_routedump_command(node_id)
-        timeout(1) do
+        Timeout.timeout(1) do
           buf = RUBY_VERSION.split('.')
           if buf[0].to_i == 1 && buf[1].to_i == 8
             return send_routedump_yaml_command(node_id)


### PR DESCRIPTION
We came to see the following warning messages because `Object#timeout` got deprecated. 
I found many deprecation messages: https://travis-ci.org/roma/roma-ruby-client/jobs/130743823

The purpose of this PR is to silence these warnings. 