### PR TITLE
Define ruby versions required to run roma-client

### DIFF
--- a/roma-client.gemspec
+++ b/roma-client.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.description = 'ROMA client library'
   s.homepage = 'http://roma-kvs.org/'
   s.license = 'GPL-3.0'
+  s.required_ruby_version = '> 2.1.0'
   s.files = Dir[
     '[A-Z]*',
     'bin/**/*',


### PR DESCRIPTION
roma-client.gemspec doesn't define `required_ruby_version` so developers can install this gem with ruby of any version even if the version is not supported. 

This pull-request provides the definition of `required_ruby_version` of `roma-client`.